### PR TITLE
Clean up after building to reduce the size of the final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,3 +60,7 @@ RUN ./bootstrap.sh && \
     make install && \
     cd lib/py && \
     python setup.py install
+
+# Clean up to reduce the size of the final image.
+WORKDIR /
+RUN rm -rf third-party


### PR DESCRIPTION
To reduce the size of the final Docker image, let's destroy the build directory once everything is built and installed.