### PR TITLE
Reduce the size of the generated Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,53 +1,63 @@
 FROM ubuntu:14.04
 MAINTAINER Seth Fowler <seth.fowler@barefootnetworks.com>
 
-# Install dependencies.
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && \
-    apt-get install -y \
-      automake \
-      bison \
-      build-essential \
-      cmake \
-      flex \
-      git \
-      libboost-dev \
-      libboost-test-dev \
-      libevent-dev \
-      libffi-dev \
-      libssl-dev \
-      libtool \
-      pkg-config \
-      python-dev \
-      python-pip
 
-# Default to using 8 make jobs, which is appropriate for local builds. On CI
-# infrastructure it will often be best to override this.
+# Default to using 2 make jobs, which is a good default for CI. If you're
+# building locally or you know there are more cores available, you may want to
+# override this.
 ARG MAKEFLAGS
-ENV MAKEFLAGS ${MAKEFLAGS:-j8}
+ENV MAKEFLAGS ${MAKEFLAGS:-j2}
 
 # Build nanomsg.
 # We use `-DCMAKE_INSTALL_PREFIX=/usr` because on Ubuntu 14.04 the library is
 # installed in /usr/local/lib/x86_64-linux-gnu/ by default, and for some reason
 # ldconfig cannot find it.
-COPY ./nanomsg /third-party/nanomsg/
-WORKDIR /third-party/nanomsg/
-RUN mkdir build && \
+ENV NANOMSG_DEPS build-essential cmake
+COPY ./nanomsg /nanomsg/
+WORKDIR /nanomsg/
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends $NANOMSG_DEPS && \
+    mkdir build && \
     cd build && \
     cmake .. -DCMAKE_INSTALL_PREFIX=/usr && \
     cmake --build . && \
-    cmake --build . --target install
+    cmake --build . --target install && \
+    apt-get purge -y $NANOMSG_DEPS && \
+    apt-get autoremove --purge -y && \
+    rm -rf /nanomsg /var/cache/apt/* /var/lib/apt/lists/*
 
 # Build nnpy.
-COPY ./nnpy /third-party/nnpy/
-WORKDIR /third-party/nnpy/
-RUN pip install cffi && \
-    pip install .
+ENV NNPY_DEPS build-essential libffi-dev python-dev python-pip
+ENV NNPY_RUNTIME_DEPS python
+COPY ./nnpy /nnpy/
+WORKDIR /nnpy/
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends $NNPY_DEPS $NNPY_RUNTIME_DEPS && \
+    pip install cffi && \
+    pip install . && \
+    apt-get purge -y $NNPY_DEPS && \
+    apt-get autoremove --purge -y && \
+    rm -rf /nnpy /var/cache/apt/* /var/lib/apt/lists/*
 
 # Build Thrift.
-COPY ./thrift /third-party/thrift/
-WORKDIR /third-party/thrift/
-RUN ./bootstrap.sh && \
+ENV THRIFT_DEPS automake \
+                bison \
+                build-essential \
+                flex \
+                libboost-dev \
+                libboost-test-dev \
+                libevent-dev \
+                libssl-dev \
+                libtool \
+                pkg-config \
+                python-dev
+ENV THRIFT_RUNTIME_DEPS libssl1.0.0 python
+COPY ./thrift /thrift/
+WORKDIR /thrift/
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends $THRIFT_DEPS $THRIFT_RUNTIME_DEPS && \
+    ./bootstrap.sh && \
     ./configure --with-cpp=yes \
                 --with-python=yes \
                 --with-c_glib=no \
@@ -59,8 +69,7 @@ RUN ./bootstrap.sh && \
     make && \
     make install && \
     cd lib/py && \
-    python setup.py install
-
-# Clean up to reduce the size of the final image.
-WORKDIR /
-RUN rm -rf third-party
+    python setup.py install && \
+    apt-get purge -y $THRIFT_DEPS && \
+    apt-get autoremove --purge -y && \
+    rm -rf /thrift /var/cache/apt/* /var/lib/apt/lists/*


### PR DESCRIPTION
This patch greatly reduces the size of the generated Docker image, at the cost of slowing down the build a bit, by deleting all unnecessary files when building each layer. Prior to this PR, the generated image was 1GB; after this PR, it's 300MB.

This will speed up Travis builds for repos that inherit from this image, because it reduces the amount of data that Travis has to download.