### PR TITLE
Add grpc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "googletest-for-protobuf"]
 	path = protobuf-deps/googletest
 	url = https://github.com/google/googletest.git
+[submodule "grpc"]
+	path = grpc
+	url = https://github.com/grpc/grpc.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,3 +100,21 @@ RUN apt-get update && \
     apt-get purge -y $PROTOCOL_BUFFERS_DEPS && \
     apt-get autoremove --purge -y && \
     rm -rf /protobuf /var/cache/apt/* /var/lib/apt/lists/*
+
+# Build gRPC.
+# The gRPC build system should detect that a version of protobuf is already
+# installed and should not try to install the third-party one included as a
+# submodule in the grpc repository.
+ENV GRPC_DEPS build-essential \
+              autoconf \
+              libtool
+COPY ./grpc /grpc/
+WORKDIR /grpc/
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends $GRPC_DEPS && \
+    make && \
+    make install && \
+    ldconfig && \
+    apt-get purge -y $GRPC_DEPS && \
+    apt-get autoremove --purge -y && \
+    rm -rf /grpc /var/cache/apt/* /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,4 +99,4 @@ RUN apt-get update && \
     ldconfig && \
     apt-get purge -y $PROTOCOL_BUFFERS_DEPS && \
     apt-get autoremove --purge -y && \
-    rm -rf /thrift /var/cache/apt/* /var/lib/apt/lists/*
+    rm -rf /protobuf /var/cache/apt/* /var/lib/apt/lists/*


### PR DESCRIPTION
gRPC is a requirement for parts of the p4lang/PI code and installing it will enable us to compile and test the entire PI code base.
    
We are pointing to released version 1.0.1 of gRPC.