### PR TITLE
Reduce image size further

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,55 @@
+**/.git
+**/.gitmodules
+**/.travis.yml
+**/AUTHORS
+**/BUILD
+**/CHANGES
+**/CHANGES.txt
+**/CONTRIBUTORS
+**/CONTRIBUTORS.txt
+**/COPYING
+**/Dockerfile
+**/NOTICE
+**/PATENTS
+**/README
+**/RELEASING
+**/*.md
+
+# Unnecessary files in nanomsg.
+nanomsg/demo
+nanomsg/doc
+nanomsg/rfc
+
+# Unnecessary files in thrift.
+thrift/contrib
+thrift/debian
+thrift/doc
+
+# Unnecessary files in protobuf and protobuf-deps.
+protobuf/csharp
+protobuf/docs
+protobuf/editors
+protobuf/examples
+protobuf/java
+protobuf/javanano
+protobuf/jenkins
+protobuf/js
+protobuf/more_tests
+protobuf/objectivec
+protobuf/php
+protobuf/ruby
+protobuf/WORKSPACE
+protobuf-deps/googlemock/msvc
+protobuf-deps/googlemock/test
+protobuf-deps/googletest/codegear
+protobuf-deps/googletest/msvc
+protobuf-deps/googletest/samples
+protobuf-deps/googletest/test
+protobuf-deps/googletest/xcode
+
+# Unnecessary files in grpc.
+grpc/doc
+grpc/examples
+grpc/summerofcode
+grpc/tools
+grpc/vsprojects

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends $NANOMSG_DEPS && \
     mkdir build && \
     cd build && \
+    export CFLAGS="-Os" && \
+    export CXXFLAGS="-Os" && \
+    export LDFLAGS="-Wl,-s" && \
     cmake .. -DCMAKE_INSTALL_PREFIX=/usr && \
     cmake --build . && \
     cmake --build . --target install && \
@@ -34,6 +37,9 @@ COPY ./nnpy /nnpy/
 WORKDIR /nnpy/
 RUN apt-get update && \
     apt-get install -y --no-install-recommends $NNPY_DEPS $NNPY_RUNTIME_DEPS && \
+    export CFLAGS="-Os" && \
+    export CXXFLAGS="-Os" && \
+    export LDFLAGS="-Wl,-s" && \
     pip install cffi && \
     pip install . && \
     apt-get purge -y $NNPY_DEPS && \
@@ -57,6 +63,9 @@ COPY ./thrift /thrift/
 WORKDIR /thrift/
 RUN apt-get update && \
     apt-get install -y --no-install-recommends $THRIFT_DEPS $THRIFT_RUNTIME_DEPS && \
+    export CFLAGS="-Os" && \
+    export CXXFLAGS="-Os" && \
+    export LDFLAGS="-Wl,-s" && \
     ./bootstrap.sh && \
     ./configure --with-cpp=yes \
                 --with-python=yes \
@@ -92,6 +101,9 @@ COPY ./protobuf-deps/googletest /protobuf/gmock/gtest
 WORKDIR /protobuf/
 RUN apt-get update && \
     apt-get install -y --no-install-recommends $PROTOCOL_BUFFERS_DEPS && \
+    export CFLAGS="-Os" && \
+    export CXXFLAGS="-Os" && \
+    export LDFLAGS="-Wl,-s" && \
     ./autogen.sh && \
     ./configure && \
     make && \
@@ -112,6 +124,7 @@ COPY ./grpc /grpc/
 WORKDIR /grpc/
 RUN apt-get update && \
     apt-get install -y --no-install-recommends $GRPC_DEPS && \
+    export LDFLAGS="-Wl,-s" && \
     make && \
     make install && \
     ldconfig && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,8 @@ RUN apt-get update && \
     cmake .. -DCMAKE_INSTALL_PREFIX=/usr && \
     cmake --build . && \
     cmake --build . --target install && \
-    apt-get purge -y $NANOMSG_DEPS && \
-    apt-get autoremove --purge -y && \
-    rm -rf /nanomsg /var/cache/apt/* /var/lib/apt/lists/*
+    apt-get remove --purge -y $NANOMSG_DEPS $(apt-mark showauto) && \
+    rm -rf /nanomsg /var/cache/apt/* /var/lib/apt/lists/* /var/cache/debconf/* /var/lib/dpkg/*-old /var/log/*
 
 # Build nnpy.
 ENV NNPY_DEPS build-essential libffi-dev python-dev python-pip
@@ -42,9 +41,8 @@ RUN apt-get update && \
     export LDFLAGS="-Wl,-s" && \
     pip install cffi && \
     pip install . && \
-    apt-get purge -y $NNPY_DEPS && \
-    apt-get autoremove --purge -y && \
-    rm -rf /nnpy /var/cache/apt/* /var/lib/apt/lists/*
+    apt-get remove --purge -y $NNPY_DEPS $(apt-mark showauto) && \
+    rm -rf /nnpy /var/cache/apt/* /var/lib/apt/lists/* /var/cache/debconf/* /var/lib/dpkg/*-old /var/log/*
 
 # Build Thrift.
 ENV THRIFT_DEPS automake \
@@ -79,9 +77,8 @@ RUN apt-get update && \
     make install && \
     cd lib/py && \
     python setup.py install && \
-    apt-get purge -y $THRIFT_DEPS && \
-    apt-get autoremove --purge -y && \
-    rm -rf /thrift /var/cache/apt/* /var/lib/apt/lists/*
+    apt-get remove --purge -y $THRIFT_DEPS $(apt-mark showauto) && \
+    rm -rf /thrift /var/cache/apt/* /var/lib/apt/lists/* /var/cache/debconf/* /var/lib/dpkg/*-old /var/log/*
 
 # Build Protocol Buffers.
 # The protobuf build system normally downloads archives of GMock and GTest from
@@ -109,9 +106,8 @@ RUN apt-get update && \
     make && \
     make install && \
     ldconfig && \
-    apt-get purge -y $PROTOCOL_BUFFERS_DEPS && \
-    apt-get autoremove --purge -y && \
-    rm -rf /protobuf /var/cache/apt/* /var/lib/apt/lists/*
+    apt-get remove --purge -y $PROTOCOL_BUFFERS_DEPS $(apt-mark showauto) && \
+    rm -rf /protobuf /var/cache/apt/* /var/lib/apt/lists/* /var/cache/debconf/* /var/lib/dpkg/*-old /var/log/*
 
 # Build gRPC.
 # The gRPC build system should detect that a version of protobuf is already
@@ -128,6 +124,5 @@ RUN apt-get update && \
     make && \
     make install && \
     ldconfig && \
-    apt-get purge -y $GRPC_DEPS && \
-    apt-get autoremove --purge -y && \
-    rm -rf /grpc /var/cache/apt/* /var/lib/apt/lists/*
+    apt-get remove --purge -y $GRPC_DEPS $(apt-mark showauto) && \
+    rm -rf /grpc /var/cache/apt/* /var/lib/apt/lists/* /var/cache/debconf/* /var/lib/dpkg/*-old /var/log/*


### PR DESCRIPTION
One piece of feedback about p4app we've received (and it's relevant to anything that uses our Docker images, really) is that the initial download takes too long, because the images are too large.

This PR halves the size of the third-party Docker image.

4ca7e44 builds these libraries with `-Os` and strips them. This reduces the size of the resulting binaries by well over a hundred megabytes.

cd5caf9 removes unneeded packages a bit more aggressively after each step, so they don't end up in the final image.

72a04aa adds as many files as possible to .dockerignore, preventing them from ending up in the final image.

These changes, combined, reduce the resulting image from 659 MB to 329 MB.