### PR TITLE
Update to Ubuntu 16.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER Seth Fowler <seth.fowler@barefootnetworks.com>
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -10,9 +10,6 @@ ARG MAKEFLAGS
 ENV MAKEFLAGS ${MAKEFLAGS:-j2}
 
 # Build nanomsg.
-# We use `-DCMAKE_INSTALL_PREFIX=/usr` because on Ubuntu 14.04 the library is
-# installed in /usr/local/lib/x86_64-linux-gnu/ by default, and for some reason
-# ldconfig cannot find it.
 ENV NANOMSG_DEPS build-essential cmake
 COPY ./nanomsg /nanomsg/
 WORKDIR /nanomsg/
@@ -23,7 +20,7 @@ RUN apt-get update && \
     export CFLAGS="-Os" && \
     export CXXFLAGS="-Os" && \
     export LDFLAGS="-Wl,-s" && \
-    cmake .. -DCMAKE_INSTALL_PREFIX=/usr && \
+    cmake .. && \
     cmake --build . && \
     cmake --build . --target install && \
     apt-get purge -y $NANOMSG_DEPS && \
@@ -31,7 +28,7 @@ RUN apt-get update && \
     rm -rf /nanomsg /var/cache/apt/* /var/lib/apt/lists/* /var/cache/debconf/* /var/lib/dpkg/*-old /var/log/*
 
 # Build nnpy.
-ENV NNPY_DEPS build-essential libffi-dev python-dev python-pip
+ENV NNPY_DEPS build-essential libffi-dev python-dev python-pip python-setuptools
 ENV NNPY_RUNTIME_DEPS python
 COPY ./nnpy /nnpy/
 WORKDIR /nnpy/
@@ -40,6 +37,7 @@ RUN apt-get update && \
     export CFLAGS="-Os" && \
     export CXXFLAGS="-Os" && \
     export LDFLAGS="-Wl,-s" && \
+    pip install wheel && \
     pip install cffi && \
     pip install . && \
     apt-get purge -y $NNPY_DEPS && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN apt-get update && \
     cmake .. -DCMAKE_INSTALL_PREFIX=/usr && \
     cmake --build . && \
     cmake --build . --target install && \
-    apt-get remove --purge -y $NANOMSG_DEPS $(apt-mark showauto) && \
+    apt-get purge -y $NANOMSG_DEPS && \
+    apt-get autoremove --purge -y && \
     rm -rf /nanomsg /var/cache/apt/* /var/lib/apt/lists/* /var/cache/debconf/* /var/lib/dpkg/*-old /var/log/*
 
 # Build nnpy.
@@ -41,7 +42,8 @@ RUN apt-get update && \
     export LDFLAGS="-Wl,-s" && \
     pip install cffi && \
     pip install . && \
-    apt-get remove --purge -y $NNPY_DEPS $(apt-mark showauto) && \
+    apt-get purge -y $NNPY_DEPS && \
+    apt-get autoremove --purge -y && \
     rm -rf /nnpy /var/cache/apt/* /var/lib/apt/lists/* /var/cache/debconf/* /var/lib/dpkg/*-old /var/log/*
 
 # Build Thrift.
@@ -77,7 +79,8 @@ RUN apt-get update && \
     make install && \
     cd lib/py && \
     python setup.py install && \
-    apt-get remove --purge -y $THRIFT_DEPS $(apt-mark showauto) && \
+    apt-get purge -y $THRIFT_DEPS && \
+    apt-get autoremove --purge -y && \
     rm -rf /thrift /var/cache/apt/* /var/lib/apt/lists/* /var/cache/debconf/* /var/lib/dpkg/*-old /var/log/*
 
 # Build Protocol Buffers.
@@ -106,7 +109,8 @@ RUN apt-get update && \
     make && \
     make install && \
     ldconfig && \
-    apt-get remove --purge -y $PROTOCOL_BUFFERS_DEPS $(apt-mark showauto) && \
+    apt-get purge -y $PROTOCOL_BUFFERS_DEPS && \
+    apt-get autoremove --purge -y && \
     rm -rf /protobuf /var/cache/apt/* /var/lib/apt/lists/* /var/cache/debconf/* /var/lib/dpkg/*-old /var/log/*
 
 # Build gRPC.
@@ -124,5 +128,6 @@ RUN apt-get update && \
     make && \
     make install && \
     ldconfig && \
-    apt-get remove --purge -y $GRPC_DEPS $(apt-mark showauto) && \
+    apt-get purge -y $GRPC_DEPS && \
+    apt-get autoremove --purge -y && \
     rm -rf /grpc /var/cache/apt/* /var/lib/apt/lists/* /var/cache/debconf/* /var/lib/dpkg/*-old /var/log/*


### PR DESCRIPTION
This PR updates us to Ubuntu 16.04. I have built the downstream Dockerfiles locally and prepared patches for all of them, so we're ready to move forward.

In 414da13 I had to undo one of the recently added image size optimizations because on Ubuntu 16.04, the new command removed a bit too much, and it was breaking downstream Dockerfiles. Despite that, though, the Ubuntu 16.04-based image is actually smaller than the current one, because the base image has shrunk in size.