### PR TITLE
Don't persist MAKEFLAGS in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # Default to using 2 make jobs, which is a good default for CI. If you're
 # building locally or you know there are more cores available, you may want to
 # override this.
-ARG MAKEFLAGS
-ENV MAKEFLAGS ${MAKEFLAGS:-j2}
+ARG MAKEFLAGS=-j2
 
 # Build nanomsg.
 ENV NANOMSG_DEPS build-essential cmake


### PR DESCRIPTION
While working on an image deep in the inheritance hierarchy that's rooted at this image, it became clear to me that persisting MAKEFLAGS in the image (by using ENV) is not a great choice, because building some packages in parallel is problematic. We're better off letting each image define it as needed.