### PR TITLE
Add scapy-vxlan

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "grpc"]
 	path = grpc
 	url = https://github.com/grpc/grpc.git
+[submodule "scapy-vxlan"]
+	path = scapy-vxlan
+	url = https://github.com/p4lang/scapy-vxlan.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,18 @@ ENV DEBIAN_FRONTEND noninteractive
 # override this.
 ARG MAKEFLAGS=-j2
 
+# Build our customized version of scapy.
+ENV SCAPY_VXLAN_DEPS python-setuptools
+ENV SCAPY_VXLAN_RUNTIME_DEPS python
+COPY ./scapy-vxlan /scapy-vxlan/
+WORKDIR /scapy-vxlan/
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends $SCAPY_VXLAN_DEPS $SCAPY_VXLAN_RUNTIME_DEPS && \
+    python setup.py install && \
+    apt-get purge -y $SCAPY_VXLAN_DEPS && \
+    apt-get autoremove --purge -y && \
+    rm -rf /scapy-vxlan /var/cache/apt/* /var/lib/apt/lists/* /var/cache/debconf/* /var/lib/dpkg/*-old /var/log/*
+
 # Build nanomsg.
 ENV NANOMSG_DEPS build-essential cmake
 COPY ./nanomsg /nanomsg/


### PR DESCRIPTION
We need scapy-vxlan to run PTF tests. In some downstream Dockerfiles, we install scapy from the Ubuntu repos. That version of scapy doesn't work with PTF tests that use vxlan, and because it's installed from a bistro-provided package it also has precedence over scapy-vxlan in PYTHONPATH, so even if you install scapy-vxlan you need to *uninstall* the scapy package to get it to work. To reduce confusion and eliminate the temptation to install the wrong version, we're better off including scapy-vxlan in this image and using it everywhere.