### PR TITLE
Add infrastructure for ccache on Travis

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "ptf"]
 	path = ptf
 	url = https://github.com/p4lang/ptf.git
+[submodule "ccache"]
+	path = ccache
+	url = https://github.com/WebHare/ccache.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 services:
   - docker
 
+cache: ccache
+
 before_install:
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 
 script:
-  - docker build --build-arg MAKEFLAGS=-j2 -t p4lang-third-party .
+  - tools/start_ccache
+  - docker build --network ccache_network --build-arg MAKEFLAGS=-j2 -t p4lang-third-party .

--- a/Dockerfile
+++ b/Dockerfile
@@ -231,7 +231,8 @@ RUN apt-get update && \
                                                $SCAPY_VXLAN_RUNTIME_DEPS \
                                                $PTF_RUNTIME_DEPS \
                                                $NNPY_RUNTIME_DEPS \
-                                               $THRIFT_RUNTIME_DEPS
+                                               $THRIFT_RUNTIME_DEPS && \
+    rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 # `pip install --user` will place things in site-packages, but Ubuntu expects
 # dist-packages by default, so we need to set PYTHONPATH.
 ENV PYTHONPATH /usr/local/lib/python2.7/site-packages

--- a/tools/start_ccache
+++ b/tools/start_ccache
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+# Create a network on which the ccache server will be exposed. Docker builds
+# will connect to this network using `--network ccache_network` to access the
+# server.
+docker network create ccache_network
+
+# Pull down the ccache server.
+docker pull webhare/ccache-memcached-server:latest
+
+# Run the ccache server, which will store its data in `$HOME/.ccache`, and make
+# it available on the network. This container will start in the background, so
+# it'll be available for any build that runs after this point.
+docker run --rm \
+           --name ccache \
+           --network ccache_network \
+           --network-alias ccache \
+           -v $HOME/.ccache:/opt/memcache-data \
+           --detach \
+           webhare/ccache-memcached-server:latest


### PR DESCRIPTION
This PR adds:

- A script that can be used to start a `memcached`-based ccache server in a Docker container, storing its data in Travis's cache. The server allows us to avoid copying the entire cache into the Docker build context.
- A ccache binary in the `third-party` image itself. A patched version is needed for `memcached` support, so we can't use the version in the Ubuntu repos.

I'm not actually *using* ccache for the builds in this repo. Doing so is a bit awkward because in this repo we're setting up the environment that other repos will use to do this, and it's not much of a win since we barely ever open PRs against this repo. I tested it in earlier version of the PR, though, and everything works. I think it's worth keeping the script in place and running just as a sanity check and a sort of documentation.