### PR TITLE
Update protobuf version to 3.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -207,6 +207,7 @@ ENV LDFLAGS="-Wl,-s"
 RUN mkdir -p /output/usr/local
 ENV PYTHONUSERBASE=/output/usr/local
 COPY --from=protobuf /output/usr/local /usr/local/
+RUN ldconfig
 COPY ./grpc /grpc/
 WORKDIR /grpc/
 RUN apt-get update


### PR DESCRIPTION
It doesn't solve the missing Python package issue, @sethfowler is working on that