### PR TITLE
Fix Python issues caused by the multistage builds refactoring

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 **/.gitmodules
 **/.travis.yml
 **/Dockerfile
+tools/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ before_install:
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 
-script:
+install:
   - tools/start_ccache
   - docker build --network ccache_network --build-arg MAKEFLAGS=-j2 -t p4lang-third-party .
+
+script:
+  - tools/run_tests

--- a/tools/run_tests
+++ b/tools/run_tests
@@ -1,0 +1,23 @@
+#!/bin/bash
+THIRD_PARTY_IMAGE=${1:-p4lang-third-party:latest}
+
+EXIT_STATUS=0
+function test_python_import() {
+  echo "- Checking 'import $1'..."
+  docker run $THIRD_PARTY_IMAGE python -c "import $1"
+  if [ $? -eq 0 ]; then
+    echo "  - PASS"
+  else
+    echo "  - FAIL"
+    EXIT_STATUS=1
+  fi
+}
+
+test_python_import "scapy"
+test_python_import "ptf"
+test_python_import "nnpy"
+test_python_import "thrift"
+test_python_import "google.protobuf"
+test_python_import "grpc"
+
+exit $EXIT_STATUS


### PR DESCRIPTION
Python has proven particularly resistant to moving files between images using a simple copy. This PR fixes several such issues:

- If you don't use `pip install --ignore-installed`, python packages that are already installed globally (e.g. because an Ubuntu package installed them) won't be installed to the user directory, which means they won't end up in the final image. That can result in missing runtime dependencies.
- A more thorough incantation is needed to really put the `site-packages` directory on equal footing with the `dist-packages` directory that Ubuntu has blessed. (This is what `site.addsitedir()` is for.)
- Always use `pip install`, and never `python setup.py install`.
- If you want to see why you shouldn't use `python setup.py install`, look at the protobuf build image and see what happens when you can't use `pip`. I've documented things in detail in comments there.

With all these changes, all of the installed python packages should be in good shape, or at least they're now broken in a more subtle way. I've added a small test script to try to ensure that such obvious bustle doesn't happen again.