### PR TITLE
Avoid polluting Docker environment.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -312,15 +312,14 @@ FROM ubuntu:16.04
 MAINTAINER Seth Fowler <sfowler@barefootnetworks.com>
 ARG DEBIAN_FRONTEND=noninteractive
 ARG MAKEFLAGS=-j2
-# Runtime dependencies
-ARG CCACHE_RUNTIME_DEPS="libmemcached-dev"
-ARG SCAPY_VXLAN_RUNTIME_DEPS="python-minimal"
-ARG PTF_RUNTIME_DEPS="libpcap-dev python-minimal tcpdump"
-ARG NNPY_RUNTIME_DEPS="python-minimal"
-ARG THRIFT_RUNTIME_DEPS="libssl1.0.0 python-minimal"
-ARG GRPC_RUNTIME_DEPS="python-minimal python-setuptools"
-ARG SYSREPO_RUNTIME_DEPS="libpcre3 libavl1 libev4 libprotobuf-c1"
-RUN apt-get update && \
+RUN CCACHE_RUNTIME_DEPS="libmemcached-dev" && \
+    SCAPY_VXLAN_RUNTIME_DEPS="python-minimal" && \
+    PTF_RUNTIME_DEPS="libpcap-dev python-minimal tcpdump" && \
+    NNPY_RUNTIME_DEPS="python-minimal" && \
+    THRIFT_RUNTIME_DEPS="libssl1.0.0 python-minimal" && \
+    GRPC_RUNTIME_DEPS="python-minimal python-setuptools" && \
+    SYSREPO_RUNTIME_DEPS="libpcre3 libavl1 libev4 libprotobuf-c1" && \
+    apt-get update && \
     apt-get install -y --no-install-recommends $CCACHE_RUNTIME_DEPS \
                                                $SCAPY_VXLAN_RUNTIME_DEPS \
                                                $PTF_RUNTIME_DEPS \

--- a/Dockerfile
+++ b/Dockerfile
@@ -312,13 +312,14 @@ FROM ubuntu:16.04
 MAINTAINER Seth Fowler <sfowler@barefootnetworks.com>
 ARG DEBIAN_FRONTEND=noninteractive
 ARG MAKEFLAGS=-j2
-ENV CCACHE_RUNTIME_DEPS libmemcached-dev
-ENV SCAPY_VXLAN_RUNTIME_DEPS python-minimal
-ENV PTF_RUNTIME_DEPS libpcap-dev python-minimal tcpdump
-ENV NNPY_RUNTIME_DEPS python-minimal
-ENV THRIFT_RUNTIME_DEPS libssl1.0.0 python-minimal
-ENV GRPC_RUNTIME_DEPS python-minimal python-setuptools
-ENV SYSREPO_RUNTIME_DEPS libpcre3 libavl1 libev4 libprotobuf-c1
+# Runtime dependencies
+ARG CCACHE_RUNTIME_DEPS="libmemcached-dev"
+ARG SCAPY_VXLAN_RUNTIME_DEPS="python-minimal"
+ARG PTF_RUNTIME_DEPS="libpcap-dev python-minimal tcpdump"
+ARG NNPY_RUNTIME_DEPS="python-minimal"
+ARG THRIFT_RUNTIME_DEPS="libssl1.0.0 python-minimal"
+ARG GRPC_RUNTIME_DEPS="python-minimal python-setuptools"
+ARG SYSREPO_RUNTIME_DEPS="libpcre3 libavl1 libev4 libprotobuf-c1"
 RUN apt-get update && \
     apt-get install -y --no-install-recommends $CCACHE_RUNTIME_DEPS \
                                                $SCAPY_VXLAN_RUNTIME_DEPS \
@@ -329,12 +330,7 @@ RUN apt-get update && \
                                                $SYSREPO_RUNTIME_DEPS && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 # Configure ccache so that descendant containers won't need to.
-ENV CCACHE_MEMCACHED_ONLY=true
-ENV CCACHE_MEMCACHED_CONF=--SERVER=ccache
-ENV CCACHE_COMPILERCHECK=content
-ENV CCACHE_CPP2=true
-ENV CCACHE_COMPRESS=true
-ENV CCACHE_MAXSIZE=1G
+COPY ./docker/ccache.conf /usr/local/etc/ccache.conf
 # Copy files from the build containers.
 COPY --from=ccache /output/usr/local /usr/local/
 COPY --from=scapy-vxlan /output/usr/local /usr/local/

--- a/docker/ccache.conf
+++ b/docker/ccache.conf
@@ -1,0 +1,5 @@
+memcached_only = true
+memcached_conf = --SERVER=ccache
+compiler_check = content
+compression = true
+max_size = 1G

--- a/docker/ccache.conf
+++ b/docker/ccache.conf
@@ -2,4 +2,5 @@ memcached_only = true
 memcached_conf = --SERVER=ccache
 compiler_check = content
 compression = true
+run_second_cpp = true
 max_size = 1G


### PR DESCRIPTION
Don't pollute Docker environment with variables that are only needed for
building the image.

Also move ccache configuration out of the environment and into a config
file so that descendant images can revert to defaults more easily. The
ccache-related environment variables override all settings, and should
only be used as a last resort. This, together with the facts that (1)
Dockerfiles don't currently provide a mechanism for unsetting
environment variables, and (2) ccache complains when its environment
variables are set but empty, make it nigh impossible for descendant
images to reliably reset ccache to defaults when ccache's configuration
is baked into the image's environment.