### PR TITLE
Optimize build with base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 # Shared Dockerfile for third party dependencies used in projects in the p4lang
 # organization.
 #
-# Because multi-stage builds are relatively new and best practices aren't yet
-# well established (as of this writing, at least), it's probably worth
-# explaining the approach used in this Dockerfile. This Dockerfile creates a
-# separate image for each third party dependency and then copies the binaries to
-# a single output image at the end. If you add a new dependency, please:
+# Best practices for multi-stage builds are available at
+# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
+#
+# The approach used in this Dockerfile is as follows:
+#
+# A multi-stage build creates a separate image for each third party dependency and
+# then copies only the binaries to a single output image at the end.
+#
+# If you add a new dependency, please:
 #   (1) Create a new build image for it. (It should have its own FROM section.)
 #   (2) Ensure that it installs everything that should be included in the final
 #       image to `/output/usr/local`. Use DESTDIR and PYTHONUSERBASE for this.
@@ -19,8 +23,9 @@
 #       runtime (as opposed to at build time), create a new _DEPS variable and
 #       install the new packages with all of the others; look at how the final
 #       image is constructed and you'll understand the pattern.
-# In general you don't have to worry about efficiency in the build images, but
-# please minimize the amount of data and the number of layers that end up in the
+#
+# In general you don't have to worry about the size of intermediate build images,
+# but please minimize the amount of data and the number of layers that end up in the
 # final image.
 
 # Build ccache.

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,153 +28,120 @@
 # but please minimize the amount of data and the number of layers that end up in the
 # final image.
 
-# Build ccache.
-FROM ubuntu:20.04 as ccache
-ARG DEBIAN_FRONTEND=noninteractive
+# Create an image with tools used as a base for the next layers
+FROM ubuntu:20.04 as base-builder
 ARG MAKEFLAGS=-j2
-ENV CCACHE_DEPS autoconf automake build-essential libmemcached-dev
-ENV CFLAGS="-Os"
-ENV CXXFLAGS="-Os"
-ENV LDFLAGS="-Wl,-s"
-RUN mkdir -p /output/usr/local
-ENV PYTHONUSERBASE=/output/usr/local
+ENV DEBIAN_FRONTEND=noninteractive \
+    CFLAGS="-Os" \
+    CXXFLAGS="-Os" \
+    LDFLAGS="-Wl,-s" \
+    PYTHONUSERBASE=/output/usr/local \
+    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/output/usr/local/lib/
+RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+        autoconf \
+        automake \
+        bison \
+        build-essential \
+        ca-certificates \
+        cmake \
+        cython \
+        flex \
+        g++ \
+        libavl-dev \
+        libboost-dev \
+        libboost-test-dev \
+        libev-dev \
+        libevent-dev \
+        libffi-dev \
+        libmemcached-dev \
+        libpcap-dev \
+        libpcre3-dev \
+        libprotobuf-c-dev \
+        libssl-dev \
+        libtool \
+        make \
+        pkg-config \
+        protobuf-c-compiler \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-setuptools && \
+    ldconfig && \
+    mkdir -p /output/usr/local
+
+# Build ccache.
+FROM base-builder as ccache
+ENV RUN_FROM_BUILD_FARM=yes
 COPY ./ccache /ccache/
 WORKDIR /ccache/
-RUN apt-get update && apt-get install -y --no-install-recommends $CCACHE_DEPS
 # Tell the ccache build system not to bother with things like documentation.
-ENV RUN_FROM_BUILD_FARM=yes
-RUN ./autogen.sh
-RUN ./configure --enable-memcached
-RUN make
+RUN ./autogen.sh && \
+    ./configure --enable-memcached && \
+    make && \
 # `make install` assumes that we *did* build the docs; make it happy.
-RUN touch ccache.1
-RUN make DESTDIR=/output install
+    touch ccache.1  && \
+    make DESTDIR=/output install
 
 # Build PTF.
-FROM ubuntu:20.04 as ptf
-ARG DEBIAN_FRONTEND=noninteractive
-ARG MAKEFLAGS=-j2
-ENV PTF_DEPS build-essential libpcap-dev python3 python3-dev python3-pip python3-setuptools
-RUN mkdir -p /output/usr/local
-ENV PYTHONUSERBASE=/output/usr/local
+FROM base-builder as ptf
 COPY ./ptf /ptf/
 WORKDIR /ptf/
-RUN apt-get update && apt-get install -y --no-install-recommends $PTF_DEPS
-RUN pip3 install --user --ignore-installed wheel
-RUN pip3 install --user --ignore-installed -rrequirements.txt
-RUN pip3 install --user --ignore-installed pypcap
-RUN pip3 install --user --ignore-installed .
+RUN pip3 install --user --ignore-installed wheel pypcap && \
+    pip3 install --user --ignore-installed -rrequirements.txt && \
+    pip3 install --user --ignore-installed .
 
 # Build nanomsg.
-FROM ubuntu:20.04 as nanomsg
-ARG DEBIAN_FRONTEND=noninteractive
-ARG MAKEFLAGS=-j2
-ENV NANOMSG_DEPS build-essential cmake
-ENV CFLAGS="-Os"
-ENV CXXFLAGS="-Os"
-ENV LDFLAGS="-Wl,-s"
-RUN mkdir /output
+FROM base-builder as nanomsg
 COPY ./nanomsg /nanomsg/
-WORKDIR /nanomsg/
-RUN apt-get update && apt-get install -y --no-install-recommends $NANOMSG_DEPS
-RUN mkdir build
+RUN mkdir -p /nanomsg/build/
 WORKDIR /nanomsg/build/
-RUN cmake ..
-RUN make DESTDIR=/output install
+RUN cmake .. && \
+    make DESTDIR=/output install
 
 # Build nnpy.
-FROM ubuntu:20.04 as nnpy
-ARG DEBIAN_FRONTEND=noninteractive
-ARG MAKEFLAGS=-j2
-ENV NNPY_DEPS build-essential libffi-dev python3 python3-dev python3-pip python3-setuptools
-ENV CFLAGS="-Os"
-ENV CXXFLAGS="-Os"
-ENV LDFLAGS="-Wl,-s"
-RUN mkdir -p /output/usr/local
-ENV PYTHONUSERBASE=/output/usr/local
+FROM base-builder as nnpy
 COPY --from=nanomsg /output/usr/local /usr/local/
 COPY ./nnpy /nnpy/
 WORKDIR /nnpy/
-RUN apt-get update && apt-get install -y --no-install-recommends $NNPY_DEPS
-RUN pip3 install --user --ignore-installed wheel
-RUN pip3 install --user --ignore-installed cffi
-RUN pip3 install --user --ignore-installed .
+RUN ldconfig && \
+    pip3 install --user --ignore-installed wheel cffi && \
+    pip3 install --user --ignore-installed .
 
 # Build Thrift.
-FROM ubuntu:20.04 as thrift
-ARG DEBIAN_FRONTEND=noninteractive
-ARG MAKEFLAGS=-j2
-ENV THRIFT_DEPS automake \
-                bison \
-                build-essential \
-                flex \
-                libboost-dev \
-                libboost-test-dev \
-                libevent-dev \
-                libssl-dev \
-                libtool \
-                pkg-config \
-                python3 \
-                python3-dev \
-                python3-pip \
-                python3-setuptools
-ENV CFLAGS="-Os"
-ENV CXXFLAGS="-Os"
-ENV LDFLAGS="-Wl,-s"
-RUN mkdir -p /output/usr/local
-ENV PYTHONUSERBASE=/output/usr/local
+FROM base-builder as thrift
 COPY ./thrift /thrift/
 WORKDIR /thrift/
-RUN apt-get update && apt-get install -y --no-install-recommends $THRIFT_DEPS
-RUN ./bootstrap.sh
-RUN ./configure --with-cpp=yes \
-                --with-python=yes \
-                --with-c_glib=no \
-                --with-java=no \
-                --with-ruby=no \
-                --with-erlang=no \
-                --with-go=no \
-                --with-nodejs=no \
-                --enable-tests=no
-RUN make
-RUN make DESTDIR=/output install-strip
+RUN ./bootstrap.sh && \
+    ./configure \
+        --with-cpp=yes \
+        --with-python=yes \
+        --with-c_glib=no \
+        --with-java=no \
+        --with-ruby=no \
+        --with-erlang=no \
+        --with-go=no \
+        --with-nodejs=no \
+        --enable-tests=no && \
+    make  && \
+    make DESTDIR=/output install-strip
 WORKDIR /thrift/lib/py/
 RUN pip3 install --user --ignore-installed .
 
 # Build Protocol Buffers.
-FROM ubuntu:20.04 as protobuf
-ARG DEBIAN_FRONTEND=noninteractive
-ARG MAKEFLAGS=-j2
-ENV PROTOCOL_BUFFERS_DEPS autoconf \
-                          automake \
-                          ca-certificates \
-                          g++ \
-                          libffi-dev \
-                          libtool \
-                          make \
-                          python3-dev \
-                          python3-setuptools \
-                          python3-pip
-ENV CFLAGS="-Os"
-ENV CXXFLAGS="-Os"
-ENV LDFLAGS="-Wl,-s"
-RUN mkdir -p /output/usr/local
-ENV PYTHONUSERBASE=/output/usr/local
+FROM base-builder as protobuf
 COPY ./protobuf /protobuf/
 WORKDIR /protobuf/
-RUN apt-get update && apt-get install -y --no-install-recommends $PROTOCOL_BUFFERS_DEPS
-RUN ./autogen.sh
-RUN ./configure
-RUN make
-RUN make DESTDIR=/output install-strip
+RUN ./autogen.sh && \
+    ./configure && \
+    make && \
+    make DESTDIR=/output install-strip
 WORKDIR /protobuf/python/
 # Protobuf is using a deprecated technique to install Python package with
 # easy install. This is causing issues since 2021-04-21. (https://discuss.python.org/t/pypi-org-recently-changed/8433)
 # We have to install pip and install six ourselves so we do not trigger the
 # broken protobuf install process.
-RUN pip3 install --user --ignore-installed wheel
-RUN pip3 install --user --ignore-installed six
-RUN python3 setup.py install --user --cpp_implementation
+RUN pip3 install --user --ignore-installed wheel six && \
+    python3 setup.py install --user --cpp_implementation
 # We'll finish up the process of building protobuf below, but first, a bit of
 # explanation.
 #
@@ -206,34 +173,19 @@ RUN export PYTHON3_VERSION=`python3 -c 'import sys; version=sys.version_info[:3]
 # The gRPC build system should detect that a version of protobuf is already
 # installed and should not try to install the third-party one included as a
 # submodule in the grpc repository.
-FROM ubuntu:20.04 as grpc
-ARG DEBIAN_FRONTEND=noninteractive
-ARG MAKEFLAGS=-j2
-ENV GRPC_DEPS build-essential \
-              cmake \
-              cython \
-              libssl-dev \
-              libtool \
-              python3-dev \
-              python3-pip \
-              python3-setuptools
-ENV LDFLAGS="-Wl,-s"
-RUN mkdir -p /output/usr/local
-ENV PYTHONUSERBASE=/output/usr/local
+FROM base-builder as grpc
 COPY --from=protobuf /output/usr/local /usr/local/
 RUN ldconfig
 COPY ./grpc /grpc/
-WORKDIR /grpc/
-RUN apt-get update && apt-get install -y --no-install-recommends $GRPC_DEPS
 # See https://github.com/grpc/grpc/blob/master/BUILDING.md
-RUN mkdir -p cmake/build
+RUN mkdir -p /grpc/cmake/build
 WORKDIR /grpc/cmake/build/
 RUN cmake ../.. \
-    -DgRPC_INSTALL=ON \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DgRPC_PROTOBUF_PROVIDER=package \
-    -DgRPC_SSL_PROVIDER=package
-RUN make DESTDIR=/output install
+      -DgRPC_INSTALL=ON \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DgRPC_PROTOBUF_PROVIDER=package \
+      -DgRPC_SSL_PROVIDER=package && \
+    make DESTDIR=/output install
 WORKDIR /grpc/
 # `pip install --user` will place things in `site-packages`, but Ubuntu expects
 # `dist-packages` by default, so we need to set configure `site-packages` as an
@@ -249,54 +201,25 @@ RUN pip3 install --user -rrequirements.txt
 RUN env GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip3 install --user --ignore-installed .
 
 # Build libyang
-FROM ubuntu:20.04 as libyang
-ARG DEBIAN_FRONTEND=noninteractive
-ARG MAKEFLAGS=-j2
-ENV LIBYANG_DEPS build-essential \
-                 cmake \
-                 libpcre3-dev
-ENV CFLAGS="-Os"
-ENV CXXFLAGS="-Os"
-ENV LDFLAGS="-Wl,-s"
-RUN mkdir /output
+FROM base-builder as libyang
 COPY ./libyang /libyang/
-RUN apt-get update && apt-get install -y --no-install-recommends $LIBYANG_DEPS
-WORKDIR /libyang/
-RUN mkdir build
+RUN mkdir -p /libyang/build/
 WORKDIR /libyang/build/
-RUN cmake ..
-RUN make DESTDIR=/output install
+RUN cmake .. && \
+    make DESTDIR=/output install
 
 # Build sysrepo
-FROM ubuntu:20.04 as sysrepo
-ARG DEBIAN_FRONTEND=noninteractive
-ARG MAKEFLAGS=-j2
-# protobuf-c is not installed as part of the protobuf image build above (it is a
-# separate Github repository). It seems that installing it from the package
-# manager rather than building it from source does not create any compatibility
-# issue.
-ENV SYSREPO_DEPS build-essential \
-                 cmake \
-                 libavl-dev \
-                 libev-dev \
-                 libprotobuf-c-dev \
-                 protobuf-c-compiler
-ENV CFLAGS="-Os"
-ENV CXXFLAGS="-Os"
-ENV LDFLAGS="-Wl,-s"
-RUN mkdir /output
+FROM base-builder as sysrepo
 COPY --from=libyang /output/usr/local /usr/local/
 RUN ldconfig
 COPY ./sysrepo /sysrepo/
-RUN apt-get update && apt-get install -y --no-install-recommends $SYSREPO_DEPS
-WORKDIR /sysrepo/
-RUN mkdir build
+RUN mkdir -p /sysrepo/build/
 WORKDIR /sysrepo/build/
 # CALL_TARGET_BINS_DIRECTLY=Off is needed here because of the use of DESTDIR
 # Without it sysrepoctl is executed at install time and assumes YANG files are
 # under /etc/sysrepo/yang
-RUN cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=Off -DCALL_TARGET_BINS_DIRECTLY=Off ..
-RUN make DESTDIR=/output install
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=Off -DCALL_TARGET_BINS_DIRECTLY=Off .. && \
+    make DESTDIR=/output install
 
 # Construct the final image.
 FROM ubuntu:20.04


### PR DESCRIPTION
This pull request adds a base-builder image as a first stage in the multi-stage Dockerfile. The base image provides basic tools and dependencies used in all other intermediate images. This allows to avoid downloading and installing the same dependencies inside each intermediate image.